### PR TITLE
GTAG documentation now uses OpcodeDB API

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -30,7 +30,7 @@ export function invokeCompiler(wsconfig: vscode.WorkspaceConfiguration,
     let cwd = path.dirname(filename);
 
     return requireCompilerPath(wsconfig).then(gta3sc => {
-        return new Promise((resolve, reject) => {
+        return new Promise<CompilerResult[]>((resolve, reject) => {
             let args = pushDataDirToArgs(wsconfig, cfgname, ["compile", filename, `--config=${cfgname}`, "--error-format=json"]);
             let buildflags = wsconfig.get(`buildflags.${cfgname}`, [])
             cp.execFile(gta3sc, args.concat(buildflags), (err, stdout, stderr) => {
@@ -101,7 +101,7 @@ export function queryModels(wsconfig: vscode.WorkspaceConfiguration,
                     askingfor: string = "default"): Promise<ModelsData>
 {
     return requireCompilerPath(wsconfig).then(gta3sc => {
-        return new Promise((resolve, reject) => {
+        return new Promise<ModelsData>((resolve, reject) => {
             let args = pushDataDirToArgs(wsconfig, cfgname, ["query-models", askingfor, `--config=${cfgname}`]);
             cp.execFile(gta3sc, args, (err, stdout, stderr) => {
                 if(err != null) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,7 +199,7 @@ function build(): Promise<void>
         return buildFile(wsconfig, cfgname, editor.document.uri.fsPath);
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         vscode.workspace.findFiles("*.sc", "").then(uris => {
             let promise = Promise.resolve();
             uris.map(uri => uri.fsPath).forEach(file => { // build one after the other
@@ -224,7 +224,7 @@ function buildFile(wsconfig: vscode.WorkspaceConfiguration,
         }
     };
 
-    return invokeCompiler(wsconfig, filename, cfgname).then(diags => {
+    return new Promise<void>(() => {invokeCompiler(wsconfig, filename, cfgname).then(diags => {
         let anyError = false;
 
         let diagnosticMap: Map<string, vscode.Diagnostic[]> = new Map();
@@ -266,5 +266,5 @@ function buildFile(wsconfig: vscode.WorkspaceConfiguration,
         if(anyError) {
             return Promise.reject("Compilation failed.")
         }
-    });
+    })});
 }


### PR DESCRIPTION
GTAG OpcodeDB API now integrated. The OpcodeDB API shall remain the most consistent and fastest (well, relatively, given the slow GTAGaming servers) way to retrieve information about opcodes/commands from the OpcodeDB.

Updated code to support TypeScript 2.2.

P.S. forgot to use closes #29