### PR TITLE
Fix game data path missing the first / from absolute paths in Linux

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -161,9 +161,8 @@ function getGameDataPath(wsconfig: vscode.WorkspaceConfiguration,
 {
     let gamebin = wsconfig.get<string[]>(`gamebin.${cfgname}`, [null]);
     if(gamebin && gamebin[0]) {
-        let components = gamebin[0].split(/\\|\//g);
-        components.pop();
-        return path.join(...components, "data");
+        let gamepath = path.parse(gamebin[0]);
+        return path.join(gamepath.dir, "data");
     }
     return null;
 }


### PR DESCRIPTION
The problem:

The root "/" is missing from the absolute path.

![image](https://github.com/user-attachments/assets/db513b5c-23a2-452c-888e-ff0c5101b60c)
![image](https://github.com/user-attachments/assets/a0abd128-89f8-49bb-b782-195bd422567b)

The fix:
Prefer using path.parse
