### PR TITLE
Fixed DEFAULTMODEL & MODEL Enum regressions

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -98,7 +98,7 @@ export function queryConfigPath(wsconfig: vscode.WorkspaceConfiguration): Promis
 /// Queries list of models from the script compiler.
 export function queryModels(wsconfig: vscode.WorkspaceConfiguration,
                     cfgname: string,
-                    askingfor: string = "default"): Promise<ModelsData>
+                    askingfor: string = "all"): Promise<ModelsData>
 {
     return requireCompilerPath(wsconfig).then(gta3sc => {
         return new Promise<ModelsData>((resolve, reject) => {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -95,7 +95,7 @@ export class GTA3ScriptController {
 
     /// Gets a specific constant list.
     public getEnumeration(name: string) : Array<[string, number]> {
-        if(name == "CARPEDMODEL") {
+        if(name == "DEFAULTMODEL") {
             return this.models.default;
         } else if(name == "MODEL") {
             // TODO FIXME this doesn't look very efficient.


### PR DESCRIPTION
1. Methods containing the DEFAULTMODEL enumeration argument did not include any of the models on completion because the enumeration name was compared to the old enumeration name “CARPEDMODEL” instead of the current name “DEFAULTMODEL”.
2. Level models were never parsed for completion because the method that queries models and parses them always used the “default” mode, i.e., output only DEFAULT models.